### PR TITLE
Clarified Carlinkit requirements

### DIFF
--- a/hardware-requirements.md
+++ b/hardware-requirements.md
@@ -15,7 +15,7 @@
 |--------|--------|
 | Argon Mini Fan | Cooling for Raspberry Pi 4, after testing multiple solutions I can only recommend this one.  |
 | Open housing for two Raspberry Pi computers  | Makes cable management easy, allows all the hardware to fit into the center console |
-| CarlinKit CPC200-Autokit, CPC200-CCPA | If you intend to use wireless CarPlay or Android Auto, for wireless Android Auto order the new model: CPC200-CCPA |
+| CarlinKit CPC200-Autokit, CPC200-CCPA | If you intend to use any form of CarPlay or Android Auto (wireless or wired). For wireless Android Auto order the new model: CPC200-CCPA |
 
 ## Notes
 

--- a/install-guide.md
+++ b/install-guide.md
@@ -138,7 +138,7 @@ NOTE: Keep in mind that overclocking calls for extra cooling for your Pi. If it 
 
 #### CarPlay
 
-Tesla Android comes with an app called AutoKit. It enables Apple CarPlay or Android auto using a dongle from Carlinkit. To ensure it works properly apply recommended configuration:
+Tesla Android comes with an app called AutoKit. It enables Apple CarPlay or Android auto using a dongle from Carlinkit (required for both wireless and wired modes). To ensure it works properly apply recommended configuration:
 - Set framerate to 30fps or 60fps. Tesla Android uses a 60Hz refresh rate, however 60Hz CarPlay is more power hungry.
 - In Advanced Settings section change Audio Channel(Beta) to Bluetooth (That is very important, this option makes it possible to connect your phone directly to the Car. This enables microphone, steering wheel controls, Siri etc).
 


### PR DESCRIPTION
- The Carlinkit requirements were previously a bit unclear on whether it was required for only *wireless* CarPlay & Android Auto or both wired and wireless.
- Per the discussion here, using wired mode on either Android Auto or CarPlay also requires the Carlinkit adapter: https://github.com/tesla-android/issue-tracker/discussions/52#discussioncomment-3057489
- This PR clarifies the requirements in both hardware-requirements.md and install-guide.md