### PR TITLE
Removing EE3372 as a modem option for the moment

### DIFF
--- a/hardware-requirements.md
+++ b/hardware-requirements.md
@@ -18,7 +18,7 @@ If you wish to run the legacy dual board configuration check out this link:
 |--------|--------|
 | Open housing for Raspberry Pi 4  | Makes cable management easy, allows all the hardware to fit into the center console |
 | CarlinKit CPC200-Autokit, CPC200-CCPA | If you intend to use any form of CarPlay or Android Auto (wireless or wired). For wireless Android Auto order the new model: CPC200-CCPA |
-| Huawei E3372(Europe), Alcatel IK41VE1(Europe), Alcatel IK41UC(North America) | Optional LTE modem, can be replaced with a different model that works on Raspbian out of the box. The modem is required if you plan on using Premium Connectivity features like online routing alongside Tesla Android. |
+| ~~Huawei E3372(Europe)~~, Alcatel IK41VE1(Europe), Alcatel IK41UC(North America). | Optional LTE modem, can be replaced with a different model that works on Raspbian out of the box. The modem is required if you plan on using Premium Connectivity features like online routing alongside Tesla Android. Huawei E3372 is not working for the single-board stack at the moment as of 2022.38.1 |
 
 ## Notes
 

--- a/install-guide.md
+++ b/install-guide.md
@@ -1,6 +1,6 @@
 ## Install guide (2022.38.1)
 
-Version 2022.38.1 is the first release that does not require a secondary Raspberry Pi board running Linux. Given that mostof the software has been either migrated or rewritten from scratch it might take a few builds to improve performance and remove new bugs. Consider trying 2022.27.1 if you are looking for the most consistent performance. 
+Version 2022.38.1 is the first release that does not require a secondary Raspberry Pi board running Linux. Given that most of the software has been either migrated or rewritten from scratch it might take a few builds to improve performance and remove new bugs. Consider trying 2022.27.1 if you are looking for the most consistent performance. 
 
 #### Upgrade from 2022.27.1
 


### PR DESCRIPTION
Since the E3372 modem is not working at the moment, I updated the hardware requirements page to reflect that

Also, made a little typo correction at the install guide page