### PR TITLE
Added notice about unsupported MCU 1

### DIFF
--- a/hardware-requirements.md
+++ b/hardware-requirements.md
@@ -1,5 +1,7 @@
 ## Hardware requirements (2022.38.1)
 
+Note: MCU 1 (cars previous to March 2018 without an infotainment upgrade) are not supported, as the built-in browser is out of date and too slow.
+
 #### Older versions
 
 If you wish to run the legacy dual board configuration check out this link: 


### PR DESCRIPTION
- Per https://github.com/tesla-android/issue-tracker/discussions/99#discussioncomment-3886369, MCU 1 is not supported because of the out-of-date browser and too slow speeds.
- This PR adds a note to the Hardware Requirements page about this, as I couldn't find it stated elsewhere.
- I have no idea if this is the right place to add it, feel free to move if there's a better spot somewhere.